### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Build status](https://travis-ci.org/jmagnusson/sqlalchemy-geonames.png?branch=master)](http://travis-ci.org/#!/jmagnusson/sqlalchemy-geonames)
 [![Code coverage](https://coveralls.io/repos/jmagnusson/sqlalchemy-geonames/badge.png?branch=master)](https://coveralls.io/r/jmagnusson/sqlalchemy-geonames)
-[![PyPI version](https://pypip.in/v/sqlalchemy-geonames/badge.png)](https://pypi.python.org/pypi/sqlalchemy-geonames)
-[![PyPI downloads](https://pypip.in/d/sqlalchemy-geonames/badge.png)](https://pypi.python.org/pypi/sqlalchemy-geonames)
+[![PyPI version](https://img.shields.io/pypi/v/sqlalchemy-geonames.svg)](https://pypi.python.org/pypi/sqlalchemy-geonames)
+[![PyPI downloads](https://img.shields.io/pypi/dm/sqlalchemy-geonames.svg)](https://pypi.python.org/pypi/sqlalchemy-geonames)
 
 Created by [Jacob Magnusson](https://twitter.com/jacobsvante_), 2013. List of contributors can be found in [CONTRIBUTORS.md](CONTRIBUTORS.md).
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20sqlalchemy-geonames))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `sqlalchemy-geonames`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.