### PR TITLE
2020 refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.pyc
 *.sublime-project
 *.sublime-workspace
+.idea
 .cache
 .coverage
 .coveralls.yml
@@ -15,3 +16,4 @@
 build/
 dist/
 MANIFEST
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,12 @@ matrix:
     - python: 3.5
       env: TOX_ENV=lint
 
+addons:
+  postgresql: 11
+  apt:
+    packages:
+    - postgresql-11-postgis-2.5
+
 install:
     - pip install tox
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     install_requires=[
         'GeoAlchemy2',
         'ipdb',
-        'progressbar2',
+        'progressbar33',
         'psycopg2',
         'requests',
         'SQLAlchemy',

--- a/sqlalchemy_geonames/bin/sqlageonames.py
+++ b/sqlalchemy_geonames/bin/sqlageonames.py
@@ -17,7 +17,6 @@ from __future__ import print_function
 import argparse
 import os
 import sys
-from copy import deepcopy
 from zipfile import ZipFile
 import requests
 from progressbar import ProgressBar, ETA, FileTransferSpeed, Percentage, Bar
@@ -56,19 +55,12 @@ def get_local_filepath(filename, download_dir=DEFAULT_DOWNLOAD_DIR):
 
 
 def get_download_config(primary_filename, language_code=DEFAULT_LANGUAGE_CODE):
-    download_config = {k: v for k, v in deepcopy(filename_config).items()
-                       if k in supported_filenames}
-    for filename, opts in download_config.items():
-        # Only download the selected primary primary_filename file
-        if (
-            filename in PRIMARY_GEONAME_FILENAMES and
-            filename != primary_filename
-        ):
-            del download_config[filename]
-        # If a file is bound to a specific language code and is not the
-        # specified one then remove it.
-        if 'language_code' in opts and opts['language_code'] != language_code:
-            del download_config[filename]
+    download_config = {}
+    for filename, opts in filename_config.items():
+        if filename in supported_filenames and not (
+                (filename in PRIMARY_GEONAME_FILENAMES and filename != primary_filename) or 'language_code' in opts and
+                opts['language_code'] != language_code):
+            download_config[filename] = opts
     return download_config
 
 

--- a/sqlalchemy_geonames/models.py
+++ b/sqlalchemy_geonames/models.py
@@ -103,8 +103,8 @@ class Geoname(GeonameBase):
     country = relationship(GeonameCountry)
 
     # alternate country codes, comma separated, ISO-3166 2-letter country
-    # code, 60 characters
-    cc2 = Column(String(60), nullable=False)
+    # code, 200 characters
+    cc2 = Column(String(200), nullable=False)
 
     # fipscode (subject to change to iso code), see exceptions below, see
     # file admin1Codes.txt for display names of this code; varchar(20)


### PR DESCRIPTION
Hey @jmagnusson, there were a couple of minor issues which prevented me from running the script successfully, this PR hopefully fixes all of them:

1. the progressbar2 dependency was broken, the script would crash with some ImportError - progressbar33 fixes this
2. I had to rewrite`get_download_config` method, because I'd get RuntimeError due to `del` statements on the dict
3. the `Geoname.cc2` field was too short for the current data and I'd get an error from Postgres complaining about data that's too long. The current recommendation on http://download.geonames.org/export/dump/ was to use 200 characters for this field